### PR TITLE
Paralelismo de memoria compartida

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@ GO = go
 HUGO = hugo
 
 CXX = g++
-CXXFLAGS = -std=c++11 -O2 -Wall -Wextra -Wpedantic
+CXXFLAGS = -std=c++11 -O2 -Wall -Wextra -Wpedantic -fopenmp
 LXX = g++
-LXXFLAGS =
+LXXFLAGS = -fopenmp -lpthread
 
 CPPSRC = \
-			src/cpp/heatmap.cpp \
-			src/cpp/main.cpp \
+	 src/cpp/heatmap.cpp \
+	 src/cpp/main.cpp \
 
 CPPHEAD = \
-			src/cpp/heatmap.hpp \
+	  src/cpp/heatmap.hpp \
 
 CPPOBJ = $(CPPSRC:.cpp=.o)
 

--- a/src/cpp/heatmap.cpp
+++ b/src/cpp/heatmap.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <omp.h>
 #include <sstream>
 #include <string>
 #include <numeric>
@@ -79,6 +80,12 @@ void Heatmap::StepFDM(double dt)
 
 	Heatmap prev = *this;
 
+// El código realiza una iteración sobre una matriz representada en formato 1D
+// (prev y map) y calcula una simulación basada en un esquema de diferencias
+// finitas en dos dimensiones.
+// El pragma #pragma omp parallel for paraleliza el bucle del índice i,
+// distribuyendo las filas de la matriz entre los hilos.
+#pragma omp parallel for
 	for (size_t i = 1; i < m - 1; ++i) {
 		for (size_t j = 1; j < n - 1; ++j) {
 			double ddT_x =


### PR DESCRIPTION
Se agrega la funcionalidad de OpenMP y se aplica al for loop que tiene el índice i para que el cálculo de las columnas se divida entre los hilos disponibles. Se hacen las modificaciones requeridas para que compile.